### PR TITLE
Matching Names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "divvunspell-python"
+name = "divvunspell"
 version = "0.1.0"
 authors = ["Brendan Molloy <brendan@bbqsrc.net>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,18 @@ authors = ["Brendan Molloy <brendan@bbqsrc.net>"]
 edition = "2018"
 
 [lib]
-name = "divvunspell-python"
+name = "divvunspell"
 crate-type = ["cdylib"]
 
 [dependencies]
-divvunspell-python = { git = "https://github.com/divvun/divvunspell", branch = "main", features = ["compression"] }
+divvunspell = { git = "https://github.com/divvun/divvunspell", branch = "main", features = ["compression"] }
 
 [dependencies.pyo3]
 version = "0.12.4"
 features = ["extension-module"]
 
 [package.metadata.maturin]
-name = "divvunspell-python"
+name = "divvunspell"
 classifiers = [
   "Programming Language :: Rust"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,18 @@ authors = ["Brendan Molloy <brendan@bbqsrc.net>"]
 edition = "2018"
 
 [lib]
-name = "divvunspell"
+name = "divvunspell-python"
 crate-type = ["cdylib"]
 
 [dependencies]
-divvunspell = { git = "https://github.com/divvun/divvunspell", branch = "main", features = ["compression"] }
+divvunspell-python = { git = "https://github.com/divvun/divvunspell", branch = "main", features = ["compression"] }
 
 [dependencies.pyo3]
 version = "0.12.4"
 features = ["extension-module"]
 
 [package.metadata.maturin]
-name = "divvunspell"
+name = "divvunspell-python"
 classifiers = [
   "Programming Language :: Rust"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "divvunspell"
+name = "divvunspell-python"
 
 [build-system]
-requires = ["maturin"]
+requires = ["maturin>=0.11,<0.12"]
 build-backend = "maturin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "divvunspell-python"
+name = "divvunspell"
 
 [build-system]
 requires = ["maturin>=0.11,<0.12"]


### PR DESCRIPTION
## What's in this PR:
* Rename `divvunspell` to `divvunspell-python`
* Specify a version for maturin (I got a warning saying this would soon be an issue)

## Why this PR:
Installing this package in one of my projects resulted in the following error:


> Requested divvunspell from git+https://github.com/divvun/divvunspell-sdk-python@7b1aeae98b9f2a5233ef073a20e0a60842ba4674#egg=divvunspell-python (from -r /tmp/pipenv-nriphpzy-requirements/pipenv-4e7d6yh3-requirement.txt (line 1)) has inconsistent name: filename has 'divvunspell-python', but metadata has 'divvunspell'

This fix resolves that issue.