### PR TITLE
Address type change for Weight

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl Speller {
         let results = speller.suggest(&word);
         Ok(results
             .into_iter()
-            .map(|x| (x.value.to_string(), x.weight))
+            .map(|x| (x.value.to_string(), x.weight.0))
             .collect::<Vec<_>>())
     }
 


### PR DESCRIPTION
divvun/divvunspell@b62f0ff3dcd11935be53f5a89db44b1cb0889507 refactored the type used for weights, breaking compilation for the maturin rust code for divvunspell python bindings.

This will likely also require a version update and pushing a new release to PyPI.